### PR TITLE
Hotfix/disable position tracking

### DIFF
--- a/Code/APHandler.cs
+++ b/Code/APHandler.cs
@@ -7,6 +7,7 @@ using ModCore;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace ArchipelagoRandomizer
 {
@@ -140,6 +141,32 @@ namespace ArchipelagoRandomizer
 				return null;
 
 			return scoutedItems.Find(x => x.LocationId - forLocation.Offset == baseId);
+		}
+
+		public void SetPosition(Vector2 position)
+		{
+			if (!IsConnected)
+			{
+				return;
+			}
+
+			var key = $"id2.pos.{CurrentPlayer.Slot}";
+			var value = $"{(int)position.x},{(int)position.y}";
+
+			Session.DataStorage[key] = value;
+		}
+
+		public void SetLevelName(string levelName)
+		{
+			if (!IsConnected)
+			{
+				return;
+			}
+
+			var key = $"id2.levelName.{CurrentPlayer.Slot}";
+			var value = levelName;
+
+			Session.DataStorage[key] = value;
 		}
 
 		private bool TryCreateSession(string url, out string errorMessage)

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -44,9 +44,9 @@ namespace ArchipelagoRandomizer
             APHandler.Instance.SetLevelName(levelName);
         }
 
-        public void OnEntityUpdate(Entity entity)
+        public void OnPlayerGetMoveDir(PlayerController playerController)
         {
-            if (entity != player)
+            if (!playerController.isMoving)
             {
                 return;
             }

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -4,18 +4,41 @@ using UnityEngine;
 
 namespace ArchipelagoRandomizer
 {
-    public class GPS
+    public class GPS : IDisposable
     {
         private static readonly TimeSpan updateInterval = TimeSpan.FromSeconds(1);
-        public static GPS Instance = new();
+        private static GPS instance = null;
+        public static GPS Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = new();
+                }
+
+                return instance;
+            }
+        }
+
         private Stopwatch UpdateTimer = Stopwatch.StartNew();
 
         Entity player;
 
         GPS()
         {
+            APHandler.Instance.OnDisconnect += Dispose;
             Events.OnPlayerSpawn += OnPlayerSpawn;
             Events.OnRoomChanged += OnRoomChanged;
+        }
+
+        public void Dispose()
+        {
+            Plugin.Log.LogMessage("Disposing the GPS");
+            APHandler.Instance.OnDisconnect -= Dispose;
+            Events.OnPlayerSpawn -= OnPlayerSpawn;
+            Events.OnRoomChanged -= OnRoomChanged;
+            instance = null;
         }
 
         private Vector2 GetPosition()

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -1,0 +1,74 @@
+using System;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace ArchipelagoRandomizer
+{
+    public class GPS
+    {
+        private const float minRequiredDistanceForUpdate = 3.0f;
+        public static GPS Instance = new();
+        private Vector2 lastPosition = Vector2.zero;
+
+
+        Entity player;
+
+        GPS()
+        {
+            Events.OnPlayerSpawn += OnPlayerSpawn;
+            Events.OnRoomChanged += OnRoomChanged;
+        }
+
+        private Vector2 GetPosition()
+        {
+            if (player == null)
+            {
+                return Vector2.zero;
+            }
+
+            return new Vector2(
+                player.transform.position.x,
+                player.transform.position.z
+            );
+        }
+
+        private void OnPlayerSpawn(Entity player, GameObject _camera, PlayerController _controller)
+        {
+            this.player = player;
+            UpdatePosition();
+        }
+
+        private void OnRoomChanged(Entity _entity, LevelRoom toRoom, LevelRoom _fromRoom, EntityEventsOwner.RoomEventData _data)
+        {
+            var levelName = toRoom.LevelRoot.LevelData.LevelName;
+            Plugin.Log.LogMessage($"YOOO, level changed to `{levelName}`");
+            APHandler.Instance.SetLevelName(levelName);
+        }
+
+        public void OnEntityUpdate(Entity entity)
+        {
+            if (entity != player)
+            {
+                return;
+            }
+
+            UpdatePosition();
+        }
+
+        public void UpdatePosition()
+        {
+            var position = GetPosition();
+            var distance = Vector2.Distance(position, lastPosition);
+
+            if (distance < minRequiredDistanceForUpdate)
+            {
+                return;
+            }
+
+            APHandler.Instance.SetPosition(position);
+
+            lastPosition = position;
+        }
+    }
+}

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -40,7 +40,6 @@ namespace ArchipelagoRandomizer
         private void OnRoomChanged(Entity _entity, LevelRoom toRoom, LevelRoom _fromRoom, EntityEventsOwner.RoomEventData _data)
         {
             var levelName = toRoom.LevelRoot.LevelData.LevelName;
-            Plugin.Log.LogMessage($"YOOO, level changed to `{levelName}`");
             APHandler.Instance.SetLevelName(levelName);
         }
 

--- a/Code/GPS.cs
+++ b/Code/GPS.cs
@@ -1,16 +1,14 @@
 using System;
+using System.Diagnostics;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 namespace ArchipelagoRandomizer
 {
     public class GPS
     {
-        private const float minRequiredDistanceForUpdate = 3.0f;
+        private static readonly TimeSpan updateInterval = TimeSpan.FromSeconds(1);
         public static GPS Instance = new();
-        private Vector2 lastPosition = Vector2.zero;
-
+        private Stopwatch UpdateTimer = Stopwatch.StartNew();
 
         Entity player;
 
@@ -58,17 +56,15 @@ namespace ArchipelagoRandomizer
 
         public void UpdatePosition()
         {
-            var position = GetPosition();
-            var distance = Vector2.Distance(position, lastPosition);
-
-            if (distance < minRequiredDistanceForUpdate)
+            if (UpdateTimer.Elapsed < updateInterval)
             {
                 return;
             }
 
-            APHandler.Instance.SetPosition(position);
+            UpdateTimer.Reset();
+            UpdateTimer.Start();
 
-            lastPosition = position;
+            APHandler.Instance.SetPosition(GetPosition());
         }
     }
 }

--- a/Code/NewFileEvents.cs
+++ b/Code/NewFileEvents.cs
@@ -51,7 +51,6 @@ namespace ArchipelagoRandomizer
 				dwSaver.SaveInt("PuzzleGate-27--47", 1);
 				dwSaver.SaveInt("PuzzleGate-27--48", 1);
 				dwSaver.SaveInt("PuzzleGate-31--36", 1);
-				dwSaver.SaveInt("PuzzleGate-40--37", 1);
 				dwSaver.SaveInt("PuzzleGate-40--35", 1);
 				dwSaver.SaveInt("PuzzleGate-49--38", 1);
 				dwSaver.SaveInt("PuzzleGate-50--38", 1);

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -162,15 +162,15 @@ namespace ArchipelagoRandomizer
 		}
 
 		[HarmonyPostfix]
-		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
-		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
+		[HarmonyPatch(typeof(PlayerController), nameof(PlayerController.GetMoveDir))]
+		public static void PlayerController_GetMoveDir_Patch(PlayerController __instance)
 		{
 			if (!ItemRandomizer.IsActive)
 			{
 				return;
 			}
 
-			GPS.Instance.OnEntityUpdate(__instance);
+			GPS.Instance.OnPlayerGetMoveDir(__instance);
 		}
 
 		// KEPT AS REFERENCE SINCE THIS WAS PAIN

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -161,6 +161,13 @@ namespace ArchipelagoRandomizer
 			APMenuStuff.Instance.DeleteAPDataFile();
 		}
 
+		[HarmonyPostfix]
+		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
+		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
+		{
+			GPS.Instance.OnEntityUpdate(__instance);
+		}
+
 		// KEPT AS REFERENCE SINCE THIS WAS PAIN
 
 		//[HarmonyPatch(typeof(SpawnItemEventObserver))]

--- a/Code/Patches.cs
+++ b/Code/Patches.cs
@@ -165,6 +165,11 @@ namespace ArchipelagoRandomizer
 		[HarmonyPatch(typeof(Entity), "IUpdatable.UpdateObject")]
 		public static void Entity_IUpdatable_UpdateObject_Patch(Entity __instance)
 		{
+			if (!ItemRandomizer.IsActive)
+			{
+				return;
+			}
+
 			GPS.Instance.OnEntityUpdate(__instance);
 		}
 

--- a/Code/PlayerActionModifier.cs
+++ b/Code/PlayerActionModifier.cs
@@ -9,6 +9,7 @@
 		public PlayerActionModifier()
 		{
 			Events.OnPlayerSpawn += OnPlayerSpawn;
+			Events.OnPlayerRespawn += OnPlayerRespawn;
 			ItemRandomizer.OnItemReceived += OnItemReceived;
 		}
 
@@ -64,6 +65,15 @@
 		{
 			this.player = player;
 
+			if (DisableStick)
+				DoModifiyStick(true);
+
+			if (DisableRoll)
+				DoModifyRoll(true);
+		}
+
+		private void OnPlayerRespawn()
+		{
 			if (DisableStick)
 				DoModifiyStick(true);
 

--- a/Code/RoomLoadEvents.cs
+++ b/Code/RoomLoadEvents.cs
@@ -116,12 +116,18 @@ namespace ArchipelagoRandomizer
 				doodads.transform.Find("KeyParent").gameObject.SetActive(false);
 		}
 
+		private void RemoveSyncopeBlockade()
+		{
+			Object.Destroy(GameObject.Find("Dream_WarningSign"));
+		}
+
 		private void OnRoomChanged(Entity entity, LevelRoom toRoom, LevelRoom fromRoom, EntityEventsOwner.RoomEventData data)
 		{
 			if (toRoom == null)
 				return;
 
 			CurrentRoom = toRoom;
+			string sceneName = SceneManager.GetActiveScene().name;
 
 			if (Plugin.IsDebug)
 			{
@@ -135,10 +141,11 @@ namespace ArchipelagoRandomizer
 				Plugin.LogDebugMessage(debugMsg);
 			}
 
-			bool doOpenRemedy = settings.IncludeSuperSecrets && SceneManager.GetActiveScene().name == "Deep13" && CurrentRoom.RoomName == "E";
-			bool doRandomizeSyncopePianoPuzzle = settings.IncludeDreamDungeons && settings.SyncopePianoPuzzle != "DEAD" && SceneManager.GetActiveScene().name == "DreamDynamite" &&
+			bool doOpenRemedy = settings.IncludeSuperSecrets && sceneName == "Deep13" && CurrentRoom.RoomName == "E";
+			bool doRandomizeSyncopePianoPuzzle = settings.IncludeDreamDungeons && settings.SyncopePianoPuzzle != "DEAD" && sceneName == "DreamDynamite" &&
 				(CurrentRoom.RoomName == "K" || CurrentRoom.RoomName == "W");
 			bool doFixSyncopeKeyDupe = settings.IncludeDreamDungeons && (toRoom.RoomName == "AF" || toRoom.RoomName == "AG");
+			bool removeSyncopeBlockade = settings.OpenDW && sceneName == "DreamWorld";
 
 			if (doOpenRemedy)
 				OpenRemedy();
@@ -148,6 +155,9 @@ namespace ArchipelagoRandomizer
 
 			if (doFixSyncopeKeyDupe)
 				FixSyncopeKeyDupe();
+
+			if (removeSyncopeBlockade)
+				RemoveSyncopeBlockade();
 		}
 	}
 }

--- a/Code/SceneLoadEvents.cs
+++ b/Code/SceneLoadEvents.cs
@@ -17,8 +17,9 @@ namespace ArchipelagoRandomizer
 				if (!settings.IncludeSuperSecrets)
 					return false;
 
+				// Require Fire Mace and Fake EFCS
 				Entity player = ModCore.Utility.GetPlayer();
-				return player.GetStateVariable("melee") == 2 || player.GetStateVariable("fakeEFCS") > 0;
+				return player.GetStateVariable("melee") == 2 && player.GetStateVariable("fakeEFCS") > 0;
 			}
 		}
 
@@ -34,12 +35,14 @@ namespace ArchipelagoRandomizer
 		{
 			this.settings = settings;
 			Events.OnSceneLoaded += OnSceneLoaded;
+			Events.OnPlayerRespawn += OnPlayerRespawn;
 			ItemRandomizer.OnItemReceived += OnItemReceieved;
 		}
 
 		public void DoDisable()
 		{
 			Events.OnSceneLoaded -= OnSceneLoaded;
+			Events.OnPlayerRespawn -= OnPlayerRespawn;
 			ItemRandomizer.OnItemReceived -= OnItemReceieved;
 		}
 
@@ -126,11 +129,6 @@ namespace ArchipelagoRandomizer
 		private void GiveTempEFCS()
 		{
 			Entity player = ModCore.Utility.GetPlayer();
-
-			// Require Fire Mace and Fake EFCS
-			if (player.GetStateVariable("melee") < 2 || player.GetStateVariable("fakeEFCS") < 1)
-				return;
-
 			player.AddLocalTempVar("melee");
 			player.SetStateVariable("melee", 3);
 		}
@@ -262,6 +260,12 @@ namespace ArchipelagoRandomizer
 
 			AddCustomComponentToItems();
 			OverrideSpawnPoints();
+		}
+
+		private void OnPlayerRespawn()
+		{
+			if (SceneName == "Deep19s" && DoGiveTempEFCS)
+				GiveTempEFCS();
 		}
 
 		private void OnItemReceieved(ItemHandler.ItemData.Item item, string sentFromPlayerName)


### PR DESCRIPTION
Position tracking currently causes the game to stutter whenever a position update is sent to the AP server.
The underlying issue seems to be related to the websocket's `SendPacketAsync` blocking more than it should.
To work around that issue, this PR disables position tracking until I've implemented a better workaround or a proper fix.
Note: The level tracking of the player suffers from the same issue, but I'll keep it enabled because it is only barely noticable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/IttleDew2_ArchipelagoRandomizer/1)
<!-- Reviewable:end -->
